### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Test/MasterCard/Api/AccountInquiryTest.php
+++ b/Test/MasterCard/Api/AccountInquiryTest.php
@@ -2,26 +2,26 @@
 /*
  * Copyright 2016 MasterCard International.
  *
- * Redistribution and use in source and binary forms, with or without modification, are 
+ * Redistribution and use in source and binary forms, with or without modification, are
  * permitted provided that the following conditions are met:
  *
- * Redistributions of source code must retain the above copyright notice, this list of 
+ * Redistributions of source code must retain the above copyright notice, this list of
  * conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of 
- * conditions and the following disclaimer in the documentation and/or other materials 
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials
  * provided with the distribution.
- * Neither the name of the MasterCard International Incorporated nor the names of its 
- * contributors may be used to endorse or promote products derived from this software 
+ * Neither the name of the MasterCard International Incorporated nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
  * without specific prior written permission.
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
- * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
  */
@@ -31,16 +31,16 @@ namespace MasterCard\Api;
 use MasterCard\Core\Model\RequestMap;
 use MasterCard\Core\ApiConfig;
 use MasterCard\Core\Security\OAuth\OAuthAuthentication;
+use PHPUnit\Framework\TestCase;
 
-
-class AccountInquiryTest extends \PHPUnit_Framework_TestCase {
+class AccountInquiryTest extends TestCase {
 
     protected function setUp() {
         $privateKey = file_get_contents(getcwd()."/mcapi_sandbox_key.p12");
         ApiConfig::setAuthentication(new OAuthAuthentication("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279!50596e52466e3966546d434b7354584c4975693238513d3d", $privateKey, "test", "password"));
         ApiConfig::setDebug(false);
     }
-    
+
     /**
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
@@ -67,7 +67,7 @@ class AccountInquiryTest extends \PHPUnit_Framework_TestCase {
     //     $this->assertEquals(strtolower("STOLEN"), strtolower($response->get("Account.Reason")));
 
     // }
-        
+
 
 
 
@@ -86,7 +86,7 @@ class AccountInquiryTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(strtolower("STOLEN"), strtolower($response->get("Account.Reason")));
 
     }
-        
+
 
     public function test_example_lost()
     {
@@ -102,11 +102,10 @@ class AccountInquiryTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-    
-    
-    
-    
-    
+
+
+
+
+
 
 }
-

--- a/Test/MasterCard/Api/BaseTest.php
+++ b/Test/MasterCard/Api/BaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/* 
+/*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
@@ -11,10 +11,11 @@ namespace MasterCard\Api;
 use MasterCard\Core\Model\RequestMap;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
+use PHPUnit\Framework\TestCase;
 
 
-abstract class BaseTest extends \PHPUnit_Framework_TestCase {
-    
+abstract class BaseTest extends TestCase {
+
     protected static $logger = null;
     public static $responses = array();
     public static $authentications = array();
@@ -22,7 +23,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase {
 
     protected function setUp() {
         self::$logger = new Logger('BaseTest');
- 
+
     }
 
     /**
@@ -83,6 +84,6 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase {
         }
     }
 
-        
-    
+
+
 }

--- a/Test/MasterCard/Api/MerchantCountriesTest.php
+++ b/Test/MasterCard/Api/MerchantCountriesTest.php
@@ -2,26 +2,26 @@
 /*
  * Copyright 2016 MasterCard International.
  *
- * Redistribution and use in source and binary forms, with or without modification, are 
+ * Redistribution and use in source and binary forms, with or without modification, are
  * permitted provided that the following conditions are met:
  *
- * Redistributions of source code must retain the above copyright notice, this list of 
+ * Redistributions of source code must retain the above copyright notice, this list of
  * conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of 
- * conditions and the following disclaimer in the documentation and/or other materials 
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials
  * provided with the distribution.
- * Neither the name of the MasterCard International Incorporated nor the names of its 
- * contributors may be used to endorse or promote products derived from this software 
+ * Neither the name of the MasterCard International Incorporated nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
  * without specific prior written permission.
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
- * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
  */
@@ -32,10 +32,10 @@ use MasterCard\Core\Model\RequestMap;
 use MasterCard\Core\ApiConfig;
 use MasterCard\Core\Security\OAuth\OAuthAuthentication;
 use MasterCard\Api\MerchantCategories;
+use PHPUnit\Framework\TestCase;
 
 
-
-class MerchantCountriesTest extends \PHPUnit_Framework_TestCase {
+class MerchantCountriesTest extends TestCase {
 
     protected function setUp() {
         ApiConfig::setDebug(false);
@@ -43,25 +43,25 @@ class MerchantCountriesTest extends \PHPUnit_Framework_TestCase {
         $privateKey = file_get_contents(getcwd()."/mcapi_sandbox_key.p12");
         ApiConfig::setAuthentication(new OAuthAuthentication("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279!50596e52466e3966546d434b7354584c4975693238513d3d", $privateKey, "test", "password"));
     }
-    
-    
-    
-    
-    
-    
-    
-                
+
+
+
+
+
+
+
+
 
         public function test_example_merchants_country()
         {
 
             $this->markTestSkipped('sandbox is down.');
-            
+
             $map = new RequestMap();
-            
+
             $map->set("details", "acceptance.paypass");
-            
-            
+
+
 
             $response = MerchantCountries::query($map);
             $this->assertEquals(str_replace("'", "", strtolower("AUSTRALIA")), strtolower(str_replace("'", "", var_export($response->get("Countries.Country[0].Name"), true))));
@@ -193,13 +193,10 @@ class MerchantCountriesTest extends \PHPUnit_Framework_TestCase {
             $this->assertEquals(str_replace("'", "", strtolower("VIRGIN ISLANDS U.S.")), strtolower(str_replace("'", "", var_export($response->get("Countries.Country[42].Name"), true))));
             $this->assertEquals(str_replace("'", "", strtolower("VIR")), strtolower(str_replace("'", "", var_export($response->get("Countries.Country[42].Code"), true))));
             $this->assertEquals(str_replace("'", "", strtolower("FALSE")), strtolower(str_replace("'", "", var_export($response->get("Countries.Country[42].Geocoding"), true))));
-            
+
 
         }
-        
-    
-    
+
+
+
 }
-
-
-

--- a/Test/MasterCard/Api/NodeJSFunctionalTest.php
+++ b/Test/MasterCard/Api/NodeJSFunctionalTest.php
@@ -33,199 +33,198 @@
  use MasterCard\Core\ApiConfig;
  use MasterCard\Core\Security\OAuth\OAuthAuthentication;
  use MasterCard\Core\Exception\InvalidRequestException;
-
+ use PHPUnit\Framework\TestCase;
 
 /**
- * 
+ *
  */
-class NodeJSFunctionalTest extends \PHPUnit_Framework_TestCase{
-    
-    
+class NodeJSFunctionalTest extends TestCase{
+
+
     public static function setUpBeforeClass() {
         $privateKey = file_get_contents(getcwd()."/mcapi_sandbox_key.p12");
         ApiConfig::setSandbox(true);
         ApiConfig::setAuthentication(new OAuthAuthentication("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279!50596e52466e3966546d434b7354584c4975693238513d3d", $privateKey, "test", "password"));
     }
-    
-    
+
+
     public function testActionReadFromPostWith200() {
-        
+
         $readItem = Post::read("1");
-        
+
         $this->assertNotNull($readItem);
-        
-        $this->assertEquals(1, $readItem->get("id"));
-        $this->assertEquals("My Title", $readItem->get("title"));
-        $this->assertEquals("some body text", $readItem->get("body"));
-        $this->assertEquals(1, $readItem->get("userId"));
-    }
-    
-    
-    public function testActionReadFromPostWith500() {
-        
-        $this->expectException(\MasterCard\Core\Exception\ApiException::class);
-        
-        $readItem = Post::read("aaa");
-        
-    }
-    
-    
-    
-    public function testActionReadFromPostWithCriteria200() {
-        
-        $tmpArray = array(
-            'one' => 1, 
-            'two' => 2,
-            'three' => 3, 
-            'four' => 4
-        );
-                
-        $readItem = Post::read("1", $tmpArray);
-        
-        $this->assertNotNull($readItem);
-        
+
         $this->assertEquals(1, $readItem->get("id"));
         $this->assertEquals("My Title", $readItem->get("title"));
         $this->assertEquals("some body text", $readItem->get("body"));
         $this->assertEquals(1, $readItem->get("userId"));
     }
 
-    
+
+    public function testActionReadFromPostWith500() {
+
+        $this->expectException(\MasterCard\Core\Exception\ApiException::class);
+
+        $readItem = Post::read("aaa");
+
+    }
+
+
+
+    public function testActionReadFromPostWithCriteria200() {
+
+        $tmpArray = array(
+            'one' => 1,
+            'two' => 2,
+            'three' => 3,
+            'four' => 4
+        );
+
+        $readItem = Post::read("1", $tmpArray);
+
+        $this->assertNotNull($readItem);
+
+        $this->assertEquals(1, $readItem->get("id"));
+        $this->assertEquals("My Title", $readItem->get("title"));
+        $this->assertEquals("some body text", $readItem->get("body"));
+        $this->assertEquals(1, $readItem->get("userId"));
+    }
+
+
     public function testActionListFromPostWith200() {
-        
-                
+
+
         $createdItems = Post::listByCriteria();
-        
+
         $this->assertEquals(true, is_array($createdItems));
-              
+
         $createdItem = $createdItems[0];
-        
+
         $this->assertEquals(1, $createdItem->get("id"));
         $this->assertEquals("My Title", $createdItem->get("title"));
         $this->assertEquals("some body text", $createdItem->get("body"));
         $this->assertEquals(1, $createdItem->get("userId"));
     }
-    
-    
-    
+
+
+
     public function testActionListFromPostWithCriteria200() {
-        
+
         $criteria = new RequestMap();
         $criteria->set("user_id", 5);
-                
+
         $createdItems = Post::listByCriteria($criteria);
-        
+
         $this->assertEquals(true, is_array($createdItems));
-              
+
         $createdItem = $createdItems[0];
-        
+
         $this->assertEquals(1, $createdItem->get("id"));
         $this->assertEquals("My Title", $createdItem->get("title"));
         $this->assertEquals("some body text", $createdItem->get("body"));
         $this->assertEquals(1, $createdItem->get("userId"));
     }
-    
-    
-        
-    
-    
+
+
+
+
+
     public function testActionCreateFromPostWith200() {
-        
+
         $requestMap = new RequestMap();
         $requestMap->set("id", 1)->set("title", "My Title")->set("body", "some long text");
-        
+
         $createdItem = Post::create($requestMap);
-        
+
         $this->assertNotNull($createdItem);
-        
-        
+
+
         $this->assertEquals(1, $createdItem->get("id"));
         $this->assertEquals("My Title", $createdItem->get("title"));
         $this->assertEquals("some body text", $createdItem->get("body"));
         $this->assertEquals(1, $createdItem->get("userId"));
     }
-    
-    
+
+
     public function testActionUpdateFromPost200() {
-        
+
         $requestMap = new RequestMap();
         $requestMap->set("id", 1)->set("title", "My Title")->set("body", "some long text");
-        
+
         $createdItem = Post::create($requestMap);
         $this->assertNotNull($createdItem);
-        
+
         $createdItem->set("body", "updated body");
         $createdItem->set("title", "updated title");
-        
+
         $updatedItem = $createdItem->update();
-        
-        
+
+
         $this->assertEquals(1, $updatedItem->get("id"));
         $this->assertEquals("updated title", $updatedItem->get("title"));
         $this->assertEquals("updated body", $updatedItem->get("body"));
         $this->assertEquals(1, $updatedItem->get("userId"));
     }
-    
+
     public function testActionDeleteFromPost200() {
-        
+
         $deletedItem = Post::deleteById("1");
-        
+
         $this->assertEquals(0, $deletedItem->size());
-               
-        
+
+
     }
-    
+
     public function testActionListFromUserPostPath200() {
         $requestMap = new RequestMap();
         $requestMap->set("user_id", 1);
-        
+
         $items =UserPostPath::listByCriteria($requestMap);
-        
+
         $this->assertEquals(true, is_array($items));
-              
+
         $item = $items[0];
-        
+
         $this->assertEquals(1, $item->get("id"));
         $this->assertEquals("My Title", $item->get("title"));
         $this->assertEquals("some body text", $item->get("body"));
         $this->assertEquals(1, $item->get("userId"));
     }
-    
+
     public function testActionListFromUserHeaderPath200() {
         $requestMap = new RequestMap();
         $requestMap->set("user_id", 1);
-        
+
         $items =  UserPostHeader::listByCriteria($requestMap);
-        
+
         $this->assertEquals(true, is_array($items));
-              
+
         $item = $items[0];
-        
+
         $this->assertEquals(1, $item->get("id"));
         $this->assertEquals("My Title", $item->get("title"));
         $this->assertEquals("some body text", $item->get("body"));
         $this->assertEquals(1, $item->get("userId"));
     }
-    
-    
+
+
     public function testActionMultipathDelete200() {
         $requestMap = new RequestMap();
         $requestMap->set("user_id", 1);
         $requestMap->set("post_id", 1);
-        
 
-        
+
+
         $deletedItem = MultiplePathUserPost::deleteById(null, $requestMap);
         $this->assertEquals(0, $deletedItem->size());
-        
+
         $requestArray = array(
-            'user_id' => 1, 
+            'user_id' => 1,
             'post_id' => 1,
         );
-        
-        $deletedItem = MultiplePathUserPost::deleteById(null, $requestArray);      
+
+        $deletedItem = MultiplePathUserPost::deleteById(null, $requestArray);
         $this->assertEquals(0, $deletedItem->size());
     }
 
 }
-

--- a/Test/MasterCard/Api/ParametersTest.php
+++ b/Test/MasterCard/Api/ParametersTest.php
@@ -2,26 +2,26 @@
 /*
  * Copyright 2016 MasterCard International.
  *
- * Redistribution and use in source and binary forms, with or without modification, are 
+ * Redistribution and use in source and binary forms, with or without modification, are
  * permitted provided that the following conditions are met:
  *
- * Redistributions of source code must retain the above copyright notice, this list of 
+ * Redistributions of source code must retain the above copyright notice, this list of
  * conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of 
- * conditions and the following disclaimer in the documentation and/or other materials 
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials
  * provided with the distribution.
- * Neither the name of the MasterCard International Incorporated nor the names of its 
- * contributors may be used to endorse or promote products derived from this software 
+ * Neither the name of the MasterCard International Incorporated nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
  * without specific prior written permission.
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
- * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
- * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
  */
@@ -31,32 +31,32 @@ namespace MasterCard\Api;
 use MasterCard\Core\Model\RequestMap;
 use MasterCard\Core\ApiConfig;
 use MasterCard\Core\Security\OAuth\OAuthAuthentication;
+use PHPUnit\Framework\TestCase;
 
 
-
-class ParametersTest extends \PHPUnit_Framework_TestCase {
+class ParametersTest extends TestCase {
 
     protected function setUp() {
         $privateKey = file_get_contents(getcwd()."/mcapi_sandbox_key.p12");
         ApiConfig::setAuthentication(new OAuthAuthentication("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279!50596e52466e3966546d434b7354584c4975693238513d3d", $privateKey, "test", "password"));
     }
-    
-    
-    
-    
-                
+
+
+
+
+
 
         public function test_example_parameters()
         {
 
             $this->markTestSkipped('sandbox is down.');
-            
+
             $map = new RequestMap();
-            
+
             $map->set("CurrentRow", "1");
             $map->set("Offset", "25");
-            
-            
+
+
 
             $response = Parameters::query($map);
             $this->assertEquals(strtolower("NO"), strtolower($response->get("ParameterList.ParameterArray.Parameter[1].Ecomm")));
@@ -73,13 +73,10 @@ class ParametersTest extends \PHPUnit_Framework_TestCase {
             $this->assertEquals(strtolower("Weekly"), strtolower($response->get("ParameterList.ParameterArray.Parameter[2].Period")));
             $this->assertEquals(strtolower("US"), strtolower($response->get("ParameterList.ParameterArray.Parameter[1].Country")));
             $this->assertEquals(strtolower("US"), strtolower($response->get("ParameterList.ParameterArray.Parameter[2].Country")));
-            
+
 
         }
-        
-    
-    
+
+
+
 }
-
-
-

--- a/Test/MasterCard/Core/ApiControllerTest.php
+++ b/Test/MasterCard/Core/ApiControllerTest.php
@@ -22,11 +22,12 @@ use MasterCard\Core\Model\OperationConfig;
 use MasterCard\Core\Model\OperationMetadata;
 use MasterCard\Core\Security\AuthenticationInterface;
 use MasterCard\Core\Security\OAuth\OAuthAuthentication;
+use PHPUnit\Framework\TestCase;
 
-class ApiControllerTest extends \PHPUnit_Framework_TestCase {
+class ApiControllerTest extends TestCase {
 
     protected function setUp() {
-        
+
         $privateKey = file_get_contents(getcwd() . "/mcapi_sandbox_key.p12");
         ApiConfig::setAuthentication(new OAuthAuthentication("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279!50596e52466e3966546d434b7354584c4975693238513d3d", $privateKey, "test", "password"));
     }
@@ -43,8 +44,8 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
 
     public function testApiConfig() {
 
-        //test default      
-        
+        //test default
+
         $this->assertEquals(Environment::SANDBOX, ApiConfig::getEnvironment());
 
         ApiConfig::setSandbox(true);
@@ -54,60 +55,60 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(Environment::PRODUCTION, ApiConfig::getEnvironment());
 
     }
-    
-    
+
+
     public function testEnvironment() {
         $controller = new ApiController("0.0.1");
 
         $inputMap = array();
         $config = ResourceConfig::getInstance();
         ApiConfig::registerResourceConfig($config);
-        
+
 
         ApiConfig::setEnvironment(Environment::SANDBOX);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
         $operationConfig = new OperationConfig("/#env/fraud/v1/account-inquiry", "create", array(), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
         $this->assertEquals("https://sandbox.api.mastercard.com/fraud/v1/account-inquiry?Format=JSON", $url);
-        
+
         //arizzini: testing isJsonNative = true
         ApiConfig::setEnvironment(Environment::SANDBOX);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext(), true);
         $operationConfig = new OperationConfig("/#env/fraud/v1/account-inquiry", "create", array(), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
         $this->assertEquals("https://sandbox.api.mastercard.com/fraud/v1/account-inquiry", $url);
-        
+
         ApiConfig::setEnvironment(Environment::PRODUCTION_ITF);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
         $operationConfig = new OperationConfig("/#env/fraud/v1/account-inquiry", "create", array(), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
         $this->assertEquals("https://api.mastercard.com/itf/fraud/v1/account-inquiry?Format=JSON", $url);
-        
+
         ApiConfig::setEnvironment(Environment::PRODUCTION_MTF);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
         $operationConfig = new OperationConfig("/#env/fraud/v1/account-inquiry", "create", array(), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
         $this->assertEquals("https://api.mastercard.com/mtf/fraud/v1/account-inquiry?Format=JSON", $url);
-        
+
         ApiConfig::setEnvironment(null);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
         $operationConfig = new OperationConfig("/#env/fraud/v1/account-inquiry", "create", array(), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
         $this->assertEquals("https://api.mastercard.com/mtf/fraud/v1/account-inquiry?Format=JSON", $url);
-        
+
         ApiConfig::setEnvironment("");
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
         $operationConfig = new OperationConfig("/#env/fraud/v1/account-inquiry", "create", array(), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
         $this->assertEquals("https://api.mastercard.com/mtf/fraud/v1/account-inquiry?Format=JSON", $url);
-        
-        
+
+
         ApiConfig::setEnvironment(Environment::PRODUCTION);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
         $operationConfig = new OperationConfig("/#env/fraud/v1/account-inquiry", "create", array(), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
         $this->assertEquals("https://api.mastercard.com/fraud/v1/account-inquiry?Format=JSON", $url);
-        
+
         ApiConfig::clearResourceConfig();
         ApiConfig::setEnvironment(Environment::SANDBOX);
     }
@@ -172,7 +173,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
 
     public function test405_not_allowed() {
         $this->expectException(Exception\ApiException::class);
-        
+
 
         $body = "{\"Errors\":{\"Error\":{\"Source\":\"System\",\"ReasonCode\":\"METHOD_NOT_ALLOWED\",\"Description\":\"Method not Allowed\",\"Recoverable\":\"false\"}}}";
         $requestMap = new RequestMap(json_decode($body, true));
@@ -190,13 +191,13 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             $this->assertEquals("METHOD_NOT_ALLOWED", $ex->getReasonCode());
             throw $ex;
         }
-        
+
     }
-    
-    
+
+
         public function test405_not_allowed_case_insensitive() {
         $this->expectException(Exception\ApiException::class);
-        
+
 
         $body = "{\"errors\":{\"error\":{\"source\":\"System\",\"reasonCode\":\"METHOD_NOT_ALLOWED\",\"description\":\"Method not Allowed\",\"recoverable\":\"false\"}}}";
         $requestMap = new RequestMap(json_decode($body, true));
@@ -214,7 +215,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             $this->assertEquals("METHOD_NOT_ALLOWED", $ex->getReasonCode());
             throw $ex;
         }
-        
+
     }
 
     public function test400_invald_request() {
@@ -236,7 +237,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             throw $ex;
         }
     }
-    
+
     public function test400_invald_request_case_insensitive() {
         $this->expectException(Exception\ApiException::class);
 
@@ -256,7 +257,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             throw $ex;
         }
     }
-    
+
 
     public function test401_unauthorised() {
         $this->expectException(Exception\ApiException::class);
@@ -299,11 +300,11 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             throw $ex;
         }
     }
-    
-    
+
+
     public function test500_invalidrequest_json_native() {
         $this->expectException(Exception\ApiException::class);
-    
+
     //
         $body = "{\"errors\":[{\"source\":\"OpenAPIClientId\",\"reasonCode\":\"AUTHORIZATION_FAILED\",\"key\":\"050007\",\"description\":\"Unauthorized Access\",\"recoverable\":false,\"requestId\":null,\"details\":{\"details\":[{\"name\":\"ErrorDetailCode\",\"value\":\"050007\"}]}}]}";
         $requestMap = new RequestMap(json_decode($body, true));
@@ -322,7 +323,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             throw $ex;
         }
     }
-    
+
     public function testGetUrlWithEmptyQueue() {
         $controller = new ApiController("0.0.1");
 
@@ -339,7 +340,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
         $config->setEnvironment(Environment::SANDBOX);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
         $operationConfig = new OperationConfig("/fraud/{api}/v{version}/account-inquiry", "create", array(), array());
-        
+
 
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
 
@@ -362,7 +363,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
         $config->setEnvironment(Environment::SANDBOX);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
 
-        
+
         $operationConfig = new OperationConfig("/fraud/{api}/v{version}/account-inquiry", "create", array('six', 'seven', 'eight'), array());
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
 
@@ -380,7 +381,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             'four' => 4,
             'five' => 5
         );
-        
+
         $config = ResourceConfig::getInstance();
         $config->setEnvironment(Environment::SANDBOX);
         $operationMetadate = new OperationMetadata("0.0.1", $config->getHost(), $config->getContext());
@@ -393,7 +394,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals("https://sandbox.api.mastercard.com/fraud/lostandstolen/v1/account-inquiry?three=3&Format=JSON", $url);
         $this->assertEquals(2, count($inputMap));
     }
-    
+
     public function testGetUrlWithOverride() {
         $controller = new ApiController("0.0.1");
 
@@ -404,7 +405,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             'four' => 4,
             'five' => 5
         );
-        
+
         $config = ResourceConfig::getInstance();
         $config->setOverride();
         $config->setEnvironment(Environment::SANDBOX);
@@ -417,7 +418,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals("http://localhost:8081/fraud/lostandstolen/v1/account-inquiry?three=3&Format=JSON", $url);
         $this->assertEquals(2, count($inputMap));
     }
-    
+
     public function test_POST_request() {
         $controller = new ApiController("0.0.1");
 
@@ -428,7 +429,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             'four' => 4,
             'five' => 5
         );
-        
+
         $config = ResourceConfig::getInstance();
         $config->setOverride();
         $config->setEnvironment(Environment::SANDBOX);
@@ -437,27 +438,27 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
 
         $operationConfig = new OperationConfig("/fraud/{api}/v{version}/account-inquiry", "create", array('one', 'two', 'three'), array());
         $request = $controller->getRequest($operationConfig, $operationMetadate, $inputMap);
-        
+
 
         $this->assertEquals("POST", $request->getMethod());
         $this->assertEquals(json_encode(array('four' => 4, 'five' => 5)), $request->getBody());
-        
+
         $headers = $request->getHeaders();
-        
+
         //arizzini: Content-Type is present
         $this->assertTrue(array_key_exists("Content-Type", $headers));
-        
+
         //arizzini: Accept is present
         $this->assertTrue(array_key_exists("Accept", $headers));
-        
+
         $this->assertEquals("mastercard-api-core(php):1.4.4/mock:0.0.1", $headers['User-Agent'][0]);
-        
+
         //arizzini: oauth_body_hash is present in OAUTH token.
         $this->assertTrue(strpos($headers['Authorization'][0], 'oauth_body_hash') !== false);
-        
+
     }
-    
-    
+
+
      public function test_GET_request() {
         $controller = new ApiController("0.0.1");
 
@@ -468,7 +469,7 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
             'four' => 4,
             'five' => 5
         );
-        
+
         $config = ResourceConfig::getInstance();
         $config->setOverride();
         $config->setEnvironment(Environment::SANDBOX);
@@ -477,28 +478,28 @@ class ApiControllerTest extends \PHPUnit_Framework_TestCase {
 
         $operationConfig = new OperationConfig("/fraud/{api}/v{version}/account-inquiry", "query", array('one', 'two', 'three'), array());
         $request = $controller->getRequest($operationConfig, $operationMetadate, $inputMap);
-        
 
-        
+
+
         $this->assertEquals("GET", $request->getMethod());
         $body = $request->getBody()->getContents();
         $this->assertTrue(empty($body));
-        
+
         $headers = $request->getHeaders();
-        
+
         //arizzini: Content-Type is not present
         $this->assertFalse(array_key_exists("Content-Type", $headers));
-        
+
         //arizzini: Accept is present
         $this->assertTrue(array_key_exists("Accept", $headers));
-        
+
         $this->assertEquals("mastercard-api-core(php):1.4.4/mock:0.0.1", $headers['User-Agent'][0]);
-        
+
         //arizzini: oauth_body_hash is not present
         $this->assertFalse(strpos($headers['Authorization'][0], 'oauth_body_hash') !== false);
-        
+
     }
-    
+
 
 
 }

--- a/Test/MasterCard/Core/Model/BaseMapTest.php
+++ b/Test/MasterCard/Core/Model/BaseMapTest.php
@@ -31,91 +31,92 @@
 namespace MasterCard\Core\Model;
 
 use MasterCard\Core\Model\RequestMap;
+use PHPUnit\Framework\TestCase;
 
-class BaseMapTest extends \PHPUnit_Framework_TestCase
+class BaseMapTest extends TestCase
 {
     public function testMap()
     {
         $baseObject = new RequestMap();
         $baseObject->set("key1", "value1");
-        
+
         $this->assertTrue($baseObject != NULL);
         $this->assertTrue($baseObject->containsKey("key1"));
         $this->assertEquals(1, $baseObject->size());
         $this->assertEquals("value1", $baseObject->get("key1"));
     }
-    
-    
+
+
     public function testMapWithListOfValues() {
         $map = new RequestMap();
         $map->set("channels[0]", "ATM");
         $map->set("channels[1]", "POS");
         $map->set("channels[2]", "ECOM");
-        
+
         $jsonString = "{\"channels\":[\"ATM\",\"POS\",\"ECOM\"]}";
-        
+
         $jsonStringFromMap = strval(json_encode($map->getBaseMapAsArray()));
 
-        
+
         $this->assertEquals($jsonString, $jsonStringFromMap);
-        
-        
+
+
         $newMap = new RequestMap();
         $newMap->setAll($map->getBaseMapAsArray());
         $jsonStringFromNewMap = strval(json_encode($newMap->getBaseMapAsArray()));
-        
+
         $this->assertEquals($jsonStringFromMap, $jsonStringFromNewMap);
-        
-        
+
+
     }
-    
-    
+
+
     public function testNestedMap()
     {
         $baseObject = new RequestMap();
         $baseObject->set("key1.key2.key3", "value1");
         $baseObject->set("key1.key2.key4", "value2");
-        
-        
+
+
         $this->assertTrue($baseObject != NULL);
-        
+
         $this->assertTrue($baseObject->containsKey("key1"));
         $this->assertTrue($baseObject->containsKey("key1.key2"));
         $this->assertTrue($baseObject->containsKey("key1.key2.key3"));
         $this->assertTrue($baseObject->size() == 1);
         $this->assertEquals("value1", $baseObject->get("key1.key2.key3"));
-        
+
         $this->assertTrue($baseObject->containsKey("key1.key2.key4"));
         $this->assertEquals("value2", $baseObject->get("key1.key2.key4"));
-        
-        
+
+
         $this->assertFalse($baseObject->containsKey("key1.key2.key3."));
         $this->assertNull($baseObject->get("key1.key2.key3."));
         $this->assertFalse($baseObject->containsKey("key1.key2."));
         $this->assertNull($baseObject->get("key1.key2."));
         $this->assertFalse($baseObject->containsKey("key1."));
         $this->assertNull($baseObject->get("key1."));
-        
+
         $this->assertFalse($baseObject->containsKey("key1.key2.something.different"));
         $this->assertNull($baseObject->get("key1.key2.something.different"));
         $this->assertFalse($baseObject->containsKey("key1.something.different"));
         $this->assertNull($baseObject->get("key1.something.different"));
         $this->assertFalse($baseObject->containsKey("key1..."));
-        $this->assertNull($baseObject->get("key1..."));           
-        
+        $this->assertNull($baseObject->get("key1..."));
+
     }
-    
+
         public function testNestedMapWithList()
     {
         $body = "[ { \"user.name\":\"andrea\", \"user.surname\":\"rizzini\" } ]";
         $baseMap = new RequestMap();
         $baseMap->setAll(json_decode($body, true));
-        
+
         $this->assertEquals(1, $baseMap->size());
         $this->assertEquals("andrea", $baseMap->get("list[0].user.name"));
         $this->assertEquals("rizzini", $baseMap->get("list[0].user.surname"));
-        
-        
+
+
         $this->assertTrue($baseMap->containsKey("list"));
         $this->assertNotEmpty($baseMap->get("list"));
         $this->assertTrue($baseMap->containsKey("list[0]"));
@@ -130,19 +131,19 @@ class BaseMapTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($baseMap->get("list[].user"));
         $this->assertTrue($baseMap->containsKey("list[0].user.name"));
         $this->assertNotEmpty($baseMap->get("list[0].user.name"));
-        
+
         $this->assertFalse($baseMap->containsKey("list2"));
         $this->assertEmpty($baseMap->get("list2"));
         $this->assertFalse($baseMap->containsKey("list[2]"));
         $this->assertEmpty($baseMap->get("list[2]"));
-        
+
         $this->assertFalse($baseMap->containsKey("list[2].some.nonsense"));
         $this->assertEmpty($baseMap->get("list[2].some.nonsense"));
         $this->assertFalse($baseMap->containsKey("list[2].some...."));
         $this->assertEmpty($baseMap->get("list[2].some...."));
-        
+
     }
-    
+
     public function testForNestedListOfMaps() {
             $map = new RequestMap();
             $map->set("payment_transfer.transfer_reference", "10017018676132929870330");
@@ -193,10 +194,10 @@ class BaseMapTest extends \PHPUnit_Framework_TestCase
 
             $jsonString = '{"payment_transfer":{"transfer_reference":"10017018676132929870330","payment_type":"P2P","amount":"1000","currency":"USD","sender_account_uri":"pan:5013040000000018;exp=2017-08;cvc=123","sender":{"first_name":"John","middle_name":"Tyler","last_name":"Jones","nationality":"USA","date_of_birth":"1994-05-21","address":{"line1":"21 Broadway","line2":"Apartment A-6","city":"OFallon","country_subdivision":"MO","postal_code":"63368","country":"USA"},"phone":"11234565555","email":" John.Jones123@abcmail.com "},"recipient_account_uri":"pan:5013040000000018;exp=2017-08;cvc=123","recipient":{"first_name":"Jane","middle_name":"Tyler","last_name":"Smith","nationality":"USA","date_of_birth":"1999-12-30","address":{"line1":"1 Main St","line2":"Apartment 9","city":"OFallon","country_subdivision":"MO","postal_code":"63368","country":"USA"},"phone":"11234567890","email":" Jane.Smith123@abcmail.com "},"reconciliation_data":{"custom_field":[{"name":" ABC","value":" 123 "},{"name":" DEF","value":" 456 "},{"name":" GHI","value":" 789 "}]},"statement_descriptor":"CLA*THANK YOU","channel":"KIOSK","funding_source":"DEBIT","text":"funding_source"}}';
             $this->assertEquals(strval($jsonString), strval(json_encode($map->getBaseMapAsArray())));
-        
-        
+
+
     }
-    
+
     public function testForNestedListOfValue() {
             $map = new RequestMap();
             $map->set("payment_transfer.transfer_reference", "40010671860312562053150");
@@ -242,33 +243,33 @@ class BaseMapTest extends \PHPUnit_Framework_TestCase
             $map->set("payment_transfer.statement_descriptor", "CLA*THANK YOU");
             $map->set("payment_transfer.channel", "KIOSK");
             $map->set("payment_transfer.text", "funding_source");
-    
+
             $this->assertTrue($map->containsKey("payment_transfer.funding_source[0]"));
             $this->assertTrue($map->containsKey("payment_transfer.funding_source[1]"));
 
             $jsonString = '{"payment_transfer":{"transfer_reference":"40010671860312562053150","payment_type":"P2P","funding_source":["CREDIT","DEBIT"],"amount":"1800","currency":"USD","sender_account_uri":"pan:5013040000000018;exp=2017-08;cvc=123","sender":{"first_name":"John","middle_name":"Tyler","last_name":"Jones","nationality":"USA","date_of_birth":"1994-05-21","address":{"line1":"21 Broadway","line2":"Apartment A-6","city":"OFallon","country_subdivision":"MO","postal_code":"63368","country":"USA"},"phone":"11234565555","email":" John.Jones123@abcmail.com "},"recipient_account_uri":"pan:5013040000000018;exp=2017-08;cvc=123","recipient":{"first_name":"Jane","middle_name":"Tyler","last_name":"Smith","nationality":"USA","date_of_birth":"1999-12-30","address":{"line1":"1 Main St","line2":"Apartment 9","city":"OFallon","country_subdivision":"MO","postal_code":"63368","country":"USA"},"phone":"11234567890","email":" Jane.Smith123@abcmail.com "},"reconciliation_data":{"custom_field":[{"name":" ABC","value":" 123 "},{"name":" DEF","value":" 456 "},{"name":" GHI","value":" 789 "}]},"statement_descriptor":"CLA*THANK YOU","channel":"KIOSK","text":"funding_source"}}';
             $this->assertEquals(strval($jsonString), strval(json_encode($map->getBaseMapAsArray())));
-        
-        
+
+
     }
-    
-    
+
+
     public function TestSetAll()
     {
         $map = array( "Account" => array( "Status" => true, "Listed" => true, "ReasonCode" => "S", "Reason" => "STOLEN"));
         $baseMap = new RequestMap();
         $baseMap->setAll($map);
-        
+
         $this->assertTrue($baseMap != NULL);
         $this->assertTrue($baseMap->containsKey("Account.Status"));
         $this->assertTrue($baseMap->size() == 1);
         $this->assertEquals("STOLEN", $baseMap->get("Account.Reason"));
-        
-        
+
+
     }
-    
 
-    
 
-            
+
+
+
 }

--- a/Test/MasterCard/Core/Security/OAuth/OAuthUtilTest.php
+++ b/Test/MasterCard/Core/Security/OAuth/OAuthUtilTest.php
@@ -35,11 +35,12 @@ use MasterCard\Core\Security\AuthenticationInterface;
 use MasterCard\Core\Security\SecurityUtil;
 use MasterCard\Core\Security\OAuth\OAuthParameters;
 use MasterCard\Core\Model\RequestMap;
+use PHPUnit\Framework\TestCase;
 
-class OAuthUtilTest extends \PHPUnit_Framework_TestCase {
+class OAuthUtilTest extends TestCase {
 
     protected $oauthAuthentication;
-    
+
     protected function setUp() {
         $privateKey = file_get_contents(getcwd()."/mcapi_sandbox_key.p12");
         $this->oauthAuthentication = new OAuthAuthentication("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279!50596e52466e3966546d434b7354584c4975693238513d3d", $privateKey, "test", "password");
@@ -78,23 +79,23 @@ class OAuthUtilTest extends \PHPUnit_Framework_TestCase {
         $baseString = OAuthAuthentication::getOAuthBaseString($url, $method, $oAuthParameters->getBaseParameters());
         $this->assertEquals("POST&http%3A%2F%2Fwww.andrea.rizzini.com%2Fsimple_service&oauth_body_hash%3DapwbAT6IoMRmB9wE9K4fNHDsaMo%253D%26oauth_consumer_key%3DL5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279%252150596e52466e3966546d434b7354584c4975693238513d3d%26oauth_nonce%3DNONCE%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3DTIMESTAMP", $baseString);
 
-        
-        
+
+
         $signature = $this->oauthAuthentication->signValue($baseString);
         $this->assertEquals("EhVW5sommBlfPSk5+RfR5LSuuvgzeMi8tiyh4+3Ao7uzyp5hjaCTi8igfwMmSfZH700BU9kUv5MOSR/keAkEXTeTBgp1eQMRSiGhHK68UeFTAyDW+mtxsrJNeftDhmkmxd2Cm8WIfmcxLUYD6g1b1QmJWEExkCkG9ztdqHT/6ef56OCEAJtAS5FfxQ5ew41hxFi0FtAdtYAepAwKdMJ1dwBiAlNmIJNYFqO61XPSnB5UtH1VR63Ti+AA0hAgZE8oH94MkksK1tkiYXzuPWuO4+kL5KQt1J2+zH8vOUSqDhQErsZxCEEF930NXafO0YyMmE4tkPEs10iaVerKo/Uu0A==", $signature);
         $oAuthParameters->setOAuthSignature($signature);
-        
+
         $baseParams = $oAuthParameters->getBaseParameters();
         $this->assertEquals(['oauth_body_hash', 'oauth_consumer_key', 'oauth_nonce', 'oauth_signature', 'oauth_signature_method', 'oauth_timestamp'], array_keys($baseParams));
-        
+
         $this->assertEquals("apwbAT6IoMRmB9wE9K4fNHDsaMo=", $baseParams['oauth_body_hash'] );
         $this->assertEquals("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279!50596e52466e3966546d434b7354584c4975693238513d3d", $baseParams['oauth_consumer_key']);
         $this->assertEquals("NONCE", $baseParams['oauth_nonce']);
         $this->assertEquals("EhVW5sommBlfPSk5+RfR5LSuuvgzeMi8tiyh4+3Ao7uzyp5hjaCTi8igfwMmSfZH700BU9kUv5MOSR/keAkEXTeTBgp1eQMRSiGhHK68UeFTAyDW+mtxsrJNeftDhmkmxd2Cm8WIfmcxLUYD6g1b1QmJWEExkCkG9ztdqHT/6ef56OCEAJtAS5FfxQ5ew41hxFi0FtAdtYAepAwKdMJ1dwBiAlNmIJNYFqO61XPSnB5UtH1VR63Ti+AA0hAgZE8oH94MkksK1tkiYXzuPWuO4+kL5KQt1J2+zH8vOUSqDhQErsZxCEEF930NXafO0YyMmE4tkPEs10iaVerKo/Uu0A==", $baseParams['oauth_signature']);
         $this->assertEquals("RSA-SHA1", $baseParams['oauth_signature_method']);
         $this->assertEquals("TIMESTAMP", $baseParams['oauth_timestamp']);
-        
-        
+
+
         $this->assertEquals("apwbAT6IoMRmB9wE9K4fNHDsaMo%3D", Util::uriRfc3986Encode($baseParams['oauth_body_hash']));
         $this->assertEquals("L5BsiPgaF-O3qA36znUATgQXwJB6MRoMSdhjd7wt50c97279%2150596e52466e3966546d434b7354584c4975693238513d3d", Util::uriRfc3986Encode($baseParams['oauth_consumer_key']));
         $this->assertEquals("NONCE", Util::uriRfc3986Encode($baseParams['oauth_nonce'] ));
@@ -102,24 +103,24 @@ class OAuthUtilTest extends \PHPUnit_Framework_TestCase {
                  Util::uriRfc3986Encode($baseParams['oauth_signature']));
         $this->assertEquals("RSA-SHA1", Util::uriRfc3986Encode($baseParams['oauth_signature_method']));
         $this->assertEquals("TIMESTAMP", Util::uriRfc3986Encode($baseParams['oauth_timestamp']) );
-        
-        
+
+
     }
-    
+
     public function testOauthSignatureFromCSharpExample()
     {
         $baseMap = new RequestMap();
         $baseMap->set("AccountInquiry.AccountNumber", "5343434343434343");
-        
-        
+
+
         $method = "PUT";
         $body = json_encode($baseMap->getBaseMapAsArray());
         $this->assertEquals('{"AccountInquiry":{"AccountNumber":"5343434343434343"}}', $body);
         $url = "https://sandbox.api.mastercard.com/fraud/loststolen/v1/account-inquiry?Format=JSON";
-        
+
         $this->assertEquals("https://sandbox.api.mastercard.com/fraud/loststolen/v1/account-inquiry?Format=JSON", $url);
 
-        
+
         $oAuthParameters = new OAuthParameters ();
         $oAuthParameters->setOAuthConsumerKey($this->oauthAuthentication->getClientId());
         $oAuthParameters->setOAuthNonce("Fl0qGYY1ZmwMzzpdN");
@@ -137,7 +138,7 @@ class OAuthUtilTest extends \PHPUnit_Framework_TestCase {
         $signature = $this->oauthAuthentication->signValue($baseString);
         $this->assertEquals("Q03RVNaPUalnH8ITeKrw13OjXneuuUcYH13aOHATnuMB57DCnK6GxW5roZkXRN6k6fuGeGlY5TYnqpK/uwc0EXEpg9XDh7UWagp+JF6TTLgT+6YF9beN5cE6GcxCsD5IVy2GZbpCrNcq5bKRKKUideHv1xUuE51nNnIorTYvFs+vbz3fDvL/v+eX4Qq2zjDUfUpwLEUhtwbcDeyTk1EvyB7j2740l2XF2s31RE9uaXZlbAZhtW+f7TmOEn0Zsx8NhZ9u3WUXVDWJkRUOWGZlf1B0oKIL52UjbP0XRc3hfCgAU0bo37V22umPfH0+vxQ0AtVHZu0doeSn8d3MDUg8CQ==", $signature);
         $oAuthParameters->setOAuthSignature($signature);
-        
+
         $baseParams = $oAuthParameters->getBaseParameters();
         $this->assertEquals(['oauth_body_hash', 'oauth_consumer_key', 'oauth_nonce', 'oauth_signature', 'oauth_signature_method', 'oauth_timestamp'], array_keys($baseParams));
         $this->assertEquals("nmtgpSOebxR/PfZyg9qwNoUEsYY=", $baseParams['oauth_body_hash'] );
@@ -146,10 +147,10 @@ class OAuthUtilTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals("Q03RVNaPUalnH8ITeKrw13OjXneuuUcYH13aOHATnuMB57DCnK6GxW5roZkXRN6k6fuGeGlY5TYnqpK/uwc0EXEpg9XDh7UWagp+JF6TTLgT+6YF9beN5cE6GcxCsD5IVy2GZbpCrNcq5bKRKKUideHv1xUuE51nNnIorTYvFs+vbz3fDvL/v+eX4Qq2zjDUfUpwLEUhtwbcDeyTk1EvyB7j2740l2XF2s31RE9uaXZlbAZhtW+f7TmOEn0Zsx8NhZ9u3WUXVDWJkRUOWGZlf1B0oKIL52UjbP0XRc3hfCgAU0bo37V22umPfH0+vxQ0AtVHZu0doeSn8d3MDUg8CQ==", $baseParams['oauth_signature']);
         $this->assertEquals("RSA-SHA1", $baseParams['oauth_signature_method']);
         $this->assertEquals("1457428003", $baseParams['oauth_timestamp']);
-       
-        
+
+
     }
- 
-    
+
+
 
 }

--- a/Test/MasterCard/Core/UtilTest.php
+++ b/Test/MasterCard/Core/UtilTest.php
@@ -30,9 +30,10 @@
 namespace MasterCard\Core;
 
 use MasterCard\Core\Model\RequestMap;
+use PHPUnit\Framework\TestCase;
 
-class UtilTest extends \PHPUnit_Framework_TestCase {
-    
+class UtilTest extends TestCase {
+
     public function testNormalizeUrl() {
         $baseUrl = "http://php.net/manual/en/function.parse-url.php";
         $this->assertEquals($baseUrl, Util::normalizeUrl($baseUrl));
@@ -69,15 +70,15 @@ class UtilTest extends \PHPUnit_Framework_TestCase {
         $url = "http://php.net/manual/en/function.parse-url.php?some=parameter&some1=parameter2";
         $this->assertEquals("http%3A%2F%2Fphp.net%2Fmanual%2Fen%2Ffunction.parse-url.php%3Fsome%3Dparameter%26some1%3Dparameter2", Util::urlEncode($url));
     }
-    
+
     public function testUri3986Encode()
     {
         $this->assertEquals("andrea%21andrea%2Aandrea%27andrea%28andrea%29", Util::uriRfc3986Encode("andrea!andrea*andrea'andrea(andrea)"));
     }
-    
-    
+
+
     public function testSubMap() {
-        
+
         $inputMap = array(
             'one' => 1,
             'two' => 2,
@@ -85,28 +86,28 @@ class UtilTest extends \PHPUnit_Framework_TestCase {
             'four' => 4,
             'five' => 5
         );
-        
+
         $keyList = array (
             'one',
             'three',
             'five'
         );
-        
+
         $subMap = Util::subMap($inputMap, $keyList);
-        
+
         $this->assertEquals(3, count($subMap));
         $this->assertEquals(1, $subMap['one']);
         $this->assertEquals(3, $subMap['three']);
         $this->assertEquals(5, $subMap['five']);
-        
+
         $this->assertEquals(2, count($inputMap));
         $this->assertEquals(2, $inputMap['two']);
         $this->assertEquals(4, $inputMap['four']);
     }
-    
-    
+
+
     public function testGetReplacedPath() {
-        
+
         $inputMap = array(
             'one' => 1,
             'two' => 2,
@@ -116,21 +117,21 @@ class UtilTest extends \PHPUnit_Framework_TestCase {
         );
         $path = "http://localhost:8080/{one}/{two}/{three}/car";
         $result = Util::getReplacedPath($path, $inputMap);
-        
+
         $this->assertEquals("http://localhost:8080/1/2/3/car", $result);
         $this->assertEquals(2, count($inputMap));
     }
-    
+
 //    public function testGetReplacedPathWithBaseMap() {
-//        
+//
 //        $inputMap = new BaseMap();
 //        $inputMap->set("one", 1)->set("two", 2)->set("three", 3)->set("four", 4)->set("five", 5);
-//            
+//
 //        $path = "http://localhost:8080/{one}/{two}/{three}/car";
 //        $result = Util::getReplacedPath($path, $inputMap);
-//        
+//
 //        $this->assertEquals("http://localhost:8080/1/2/3/car", $result);
 //        $this->assertEquals(2, count($inputMap));
 //    }
-    
+
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "monolog/monolog": "^1.19"
     },
     "require-dev": {
-	"phpunit/phpunit": "^5.2"
+	"phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.