### PR TITLE
Refactoring tests

### DIFF
--- a/Test/MasterCard/Api/NodeJSFunctionalTest.php
+++ b/Test/MasterCard/Api/NodeJSFunctionalTest.php
@@ -96,7 +96,7 @@ class NodeJSFunctionalTest extends BaseTest{
                 
         $createdItems = Post::listByCriteria();
         
-        $this->assertEquals(true, is_array($createdItems));
+        $this->assertInternalType('array', $createdItems);
               
         $createdItem = $createdItems[0];
         
@@ -115,7 +115,7 @@ class NodeJSFunctionalTest extends BaseTest{
                 
         $createdItems = Post::listByCriteria($criteria);
         
-        $this->assertEquals(true, is_array($createdItems));
+        $this->assertInternalType('array', $createdItems);
               
         $createdItem = $createdItems[0];
         
@@ -181,7 +181,7 @@ class NodeJSFunctionalTest extends BaseTest{
         
         $items =UserPostPath::listByCriteria($requestMap);
         
-        $this->assertEquals(true, is_array($items));
+        $this->assertInternalType('array', $items);
               
         $item = $items[0];
         
@@ -197,7 +197,7 @@ class NodeJSFunctionalTest extends BaseTest{
         
         $items =  UserPostHeader::listByCriteria($requestMap);
         
-        $this->assertEquals(true, is_array($items));
+        $this->assertInternalType('array', $items);
               
         $item = $items[0];
         

--- a/Test/MasterCard/Core/ApiControllerTest.php
+++ b/Test/MasterCard/Core/ApiControllerTest.php
@@ -345,7 +345,7 @@ class ApiControllerTest extends TestCase {
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
 
         $this->assertEquals("https://sandbox.api.mastercard.com/fraud/lostandstolen/v1/account-inquiry?Format=JSON", $url);
-        $this->assertEquals(3, count($inputMap));
+        $this->assertCount(3, $inputMap);
     }
 
     public function testGetUrlWithNonMatchingQueue() {
@@ -368,7 +368,7 @@ class ApiControllerTest extends TestCase {
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
 
         $this->assertEquals("https://sandbox.api.mastercard.com/fraud/lostandstolen/v1/account-inquiry?Format=JSON", $url);
-        $this->assertEquals(3, count($inputMap));
+        $this->assertCount(3, $inputMap);
     }
 
     public function testGetUrlWithQuery() {
@@ -392,7 +392,7 @@ class ApiControllerTest extends TestCase {
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
 
         $this->assertEquals("https://sandbox.api.mastercard.com/fraud/lostandstolen/v1/account-inquiry?three=3&Format=JSON", $url);
-        $this->assertEquals(2, count($inputMap));
+        $this->assertCount(2, $inputMap);
     }
     
     public function testGetUrlWithOverride() {
@@ -416,7 +416,7 @@ class ApiControllerTest extends TestCase {
         $url = $controller->getUrl($operationConfig, $operationMetadate, $inputMap);
 
         $this->assertEquals("http://localhost:8081/fraud/lostandstolen/v1/account-inquiry?three=3&Format=JSON", $url);
-        $this->assertEquals(2, count($inputMap));
+        $this->assertCount(2, $inputMap);
     }
     
     public function test_POST_request() {
@@ -446,15 +446,15 @@ class ApiControllerTest extends TestCase {
         $headers = $request->getHeaders();
         
         //arizzini: Content-Type is present
-        $this->assertTrue(array_key_exists("Content-Type", $headers));
+        $this->assertArrayHasKey("Content-Type", $headers);
         
         //arizzini: Accept is present
-        $this->assertTrue(array_key_exists("Accept", $headers));
+        $this->assertArrayHasKey("Accept", $headers);
         
         $this->assertEquals("mastercard-api-core(php):1.4.5/mock:0.0.1", $headers['User-Agent'][0]);
         
         //arizzini: oauth_body_hash is present in OAUTH token.
-        $this->assertTrue(strpos($headers['Authorization'][0], 'oauth_body_hash') !== false);
+        $this->assertContains('oauth_body_hash', $headers['Authorization'][0]);
         
     }
     
@@ -485,16 +485,16 @@ class ApiControllerTest extends TestCase {
         $headers = $request->getHeaders();
         
         //arizzini: Content-Type is present
-        $this->assertTrue(array_key_exists("Content-Type", $headers));
+        $this->assertArrayHasKey("Content-Type", $headers);
         $this->assertEquals("text/json; charset=utf-8", $headers['Content-Type'][0]);
         //arizzini: Accept is present
-        $this->assertTrue(array_key_exists("Accept", $headers));
+        $this->assertArrayHasKey("Accept", $headers);
         $this->assertEquals("text/json; charset=utf-8", $headers['Accept'][0]);
         
         $this->assertEquals("mastercard-api-core(php):1.4.5/mock:0.0.1", $headers['User-Agent'][0]);
         
         //arizzini: oauth_body_hash is present in OAUTH token.
-        $this->assertTrue(strpos($headers['Authorization'][0], 'oauth_body_hash') !== false);
+        $this->assertContains('oauth_body_hash', $headers['Authorization'][0]);
         
     }
     
@@ -523,20 +523,20 @@ class ApiControllerTest extends TestCase {
         
         $this->assertEquals("GET", $request->getMethod());
         $body = $request->getBody()->getContents();
-        $this->assertTrue(empty($body));
+        $this->assertEmpty($body);
         
         $headers = $request->getHeaders();
         
         //arizzini: Content-Type is not present
-        $this->assertFalse(array_key_exists("Content-Type", $headers));
+        $this->assertArrayNotHasKey("Content-Type", $headers);
         
         //arizzini: Accept is present
-        $this->assertTrue(array_key_exists("Accept", $headers));
+        $this->assertArrayHasKey("Accept", $headers);
         
         $this->assertEquals("mastercard-api-core(php):1.4.5/mock:0.0.1", $headers['User-Agent'][0]);
         
         //arizzini: oauth_body_hash is not present
-        $this->assertFalse(strpos($headers['Authorization'][0], 'oauth_body_hash') !== false);
+        $this->assertNotContains('oauth_body_hash', $headers['Authorization'][0]);
         
     }
     

--- a/Test/MasterCard/Core/Model/BaseMapTest.php
+++ b/Test/MasterCard/Core/Model/BaseMapTest.php
@@ -40,7 +40,7 @@ class BaseMapTest extends TestCase
         $baseObject = new RequestMap();
         $baseObject->set("key1", "value1");
         
-        $this->assertTrue($baseObject != NULL);
+        $this->assertNotEquals(NULL, $baseObject);
         $this->assertTrue($baseObject->containsKey("key1"));
         $this->assertEquals(1, $baseObject->size());
         $this->assertEquals("value1", $baseObject->get("key1"));
@@ -78,12 +78,12 @@ class BaseMapTest extends TestCase
         $baseObject->set("key1.key2.key4", "value2");
         
         
-        $this->assertTrue($baseObject != NULL);
+        $this->assertNotEquals(NULL, $baseObject);
         
         $this->assertTrue($baseObject->containsKey("key1"));
         $this->assertTrue($baseObject->containsKey("key1.key2"));
         $this->assertTrue($baseObject->containsKey("key1.key2.key3"));
-        $this->assertTrue($baseObject->size() == 1);
+        $this->assertEquals(1, $baseObject->size());
         $this->assertEquals("value1", $baseObject->get("key1.key2.key3"));
         
         $this->assertTrue($baseObject->containsKey("key1.key2.key4"));
@@ -260,9 +260,9 @@ class BaseMapTest extends TestCase
         $baseMap = new RequestMap();
         $baseMap->setAll($map);
         
-        $this->assertTrue($baseMap != NULL);
+        $this->assertNotEquals(NULL, $baseMap);
         $this->assertTrue($baseMap->containsKey("Account.Status"));
-        $this->assertTrue($baseMap->size() == 1);
+        $this->assertEquals(1, $baseMap->size());
         $this->assertEquals("STOLEN", $baseMap->get("Account.Reason"));
         
         

--- a/Test/MasterCard/Core/Security/OAuth/OAuthUtilTest.php
+++ b/Test/MasterCard/Core/Security/OAuth/OAuthUtilTest.php
@@ -50,13 +50,13 @@ class OAuthUtilTest extends TestCase {
     public function testGetNonce() {
         $nonce = SecurityUtil::getNonce();
         $this->assertNotNull($nonce);
-        $this->assertTrue(strlen($nonce) == 16);
+        $this->assertSame(16, strlen($nonce));
     }
 
     public function testGetTimestamp() {
         $nonce = SecurityUtil::getTimestamp();
         $this->assertNotNull($nonce);
-        $this->assertTrue(strlen($nonce) == 10);
+        $this->assertSame(10, strlen($nonce));
     }
 
 

--- a/Test/MasterCard/Core/UtilTest.php
+++ b/Test/MasterCard/Core/UtilTest.php
@@ -95,12 +95,12 @@ class UtilTest extends TestCase{
         
         $subMap = Util::subMap($inputMap, $keyList);
         
-        $this->assertEquals(3, count($subMap));
+        $this->assertCount(3, $subMap);
         $this->assertEquals(1, $subMap['one']);
         $this->assertEquals(3, $subMap['three']);
         $this->assertEquals(5, $subMap['five']);
         
-        $this->assertEquals(2, count($inputMap));
+        $this->assertCount(2, $inputMap);
         $this->assertEquals(2, $inputMap['two']);
         $this->assertEquals(4, $inputMap['four']);
     }
@@ -119,7 +119,7 @@ class UtilTest extends TestCase{
         $result = Util::getReplacedPath($path, $inputMap);
         
         $this->assertEquals("http://localhost:8080/1/2/3/car", $result);
-        $this->assertEquals(2, count($inputMap));
+        $this->assertCount(2, $inputMap);
     }
     
 //    public function testGetReplacedPathWithBaseMap() {


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInternalType`, avoiding using `is_*` functions;
- `assertArrayHasKey` instead of `array_key_exists` function;
- `assertEmpty` instead of `empty` function;
- `assertNotFalse` instead of comparison with `false` keyword;
- `assertNotNull` instead of comparison with `null` keyword.